### PR TITLE
Send basic tofi history to Toaster-ToasterDB

### DIFF
--- a/cmd/cook.go
+++ b/cmd/cook.go
@@ -91,6 +91,8 @@ var cookCmd = &cobra.Command{
 			log.Println("TofuGu removed tofi temp dir: " + tofuguStruct.CmdWorkTempDir)
 		}
 
+		tofuguStruct.SendHistoryData(cmdToExec, cmdArgs, exitCodeFinal)
+
 		log.Printf("TofuGu: %v finished with code %v", cmdToExec, exitCodeFinal)
 		os.Exit(exitCodeFinal)
 	},

--- a/utils/structures.go
+++ b/utils/structures.go
@@ -30,3 +30,11 @@ type DimensionInToaster struct {
 	WorkSpace string
 	DimData   map[string]interface{}
 }
+
+type HistoryStruct struct {
+	CmdToExec  string
+	CmdArgs    []string
+	CmdMainArg string
+	ExitCode   int
+	Dimensions map[string]string
+}


### PR DESCRIPTION
Implemented basic history POST request to Toaster
Info stored in ToasterDB like
```json
{
  "_id": { "$oid": "66367db93509ca433fdcfb06" },
  "orgname": "demo-org",
  "workspace": "master",
  "tofiname": "vpc",
  "cmdtoexec": "tofu",
  "cmdargs": [
    "-backend-config=bucket=default-tfstates",
    "-backend-config=key=org_demo-org/account_test-account/datacenter_staging1/vpc.tfstate",
    "-backend-config=region=us-east-2"
  ],
  "cmdmainarg": "init",
  "exitcode": { "$numberInt": "1" },
  "dimensions": {
    "account": "test-account",
    "datacenter": "staging1"
  },
  "accountid": "662cab7c5e226819838b01fa",
  "datecreated": {
    "$date": { "$numberLong": "1714846798515" }
  }
}
```